### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/retuve/app/routes/api.py
+++ b/retuve/app/routes/api.py
@@ -72,7 +72,7 @@ async def store_feedback(
         }
     except Exception as e:
         ulogger.info(e)
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": "An internal error has occurred."}
 
 
 @router.get("/api/get_feedback/{keyphrase}")


### PR DESCRIPTION
Potential fix for [https://github.com/radoss-org/retuve/security/code-scanning/2](https://github.com/radoss-org/retuve/security/code-scanning/2)

To fix the problem, the code should be modified so that the user receives only a generic error message, while the actual exception details are logged on the server for debugging purposes. Specifically, in the exception handler of the `/api/store_feedback/{keyphrase}` endpoint, replace the line that returns the exception message to the user with a generic message such as "An internal error has occurred." The logging of the exception can remain as is, or be improved to include the stack trace if desired. Only the return value to the user needs to be changed.

**Required changes:**
- In `retuve/app/routes/api.py`, in the exception handler of the `store_feedback` function, replace `{"status": "error", "message": str(e)}` with `{"status": "error", "message": "An internal error has occurred."}`.
- Optionally, improve the logging to include the stack trace by using `uloger.exception(e)` or logging `traceback.format_exc()`, but this is not strictly required for the fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
